### PR TITLE
feat(auth): logged in state and logout button

### DIFF
--- a/Frontend/src/app/app-routing.module.ts
+++ b/Frontend/src/app/app-routing.module.ts
@@ -1,14 +1,12 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { HomeComponent } from './home/home.component';
-import { LoginPageComponent } from './login-page/login-page.component';
 import { UserProfileComponent } from './user-profile/user-profile.component';
 import { UserFeedComponent } from './user-feed/user-feed.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
   { path: 'home', component: HomeComponent },
-  { path: 'login', component: LoginPageComponent},
   { path: 'profile', component: UserProfileComponent},
   { path: 'feed', component: UserFeedComponent}
 ];

--- a/Frontend/src/app/home/home.component.css
+++ b/Frontend/src/app/home/home.component.css
@@ -38,6 +38,17 @@
     left: 0;
     position: absolute;
     width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.header-left {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
 }
 
 .iconClass {

--- a/Frontend/src/app/home/home.component.html
+++ b/Frontend/src/app/home/home.component.html
@@ -3,25 +3,35 @@
 <button routerLink="/profile">user profile</button>
 
   <mat-toolbar id="header">
-    <button mat-icon-button class="example-icon" [matMenuTriggerFor]="menu" aria-label="Example icon-button with menu icon">
-      <mat-icon class="iconClass">menu</mat-icon>
-    </button>
-    <span>Welcome to Fakebook (TM)</span>
-    <span class="example-spacer"></span>
-    <mat-menu #menu="matMenu">
-        <button mat-menu-item routerLink="/login">
-          <mat-icon [ngStyle]="{'color':'orangered'}">login</mat-icon>
-          <span>Login</span>
-        </button>
+    <div class="header-left">
+      <button mat-icon-button class="example-icon" [matMenuTriggerFor]="menu" aria-label="Example icon-button with menu icon">
+        <mat-icon class="iconClass">menu</mat-icon>
+      </button>
+      <span>Welcome to Fakebook (TM)</span>
+      <span class="example-spacer"></span>
+      <mat-menu #menu="matMenu">
         <button mat-menu-item>
           <mat-icon [ngStyle]="{'color':'orangered'}">info</mat-icon>
           <span>About</span>
         </button>
-        <button mat-menu-item>
-          <mat-icon [ngStyle]="{'color':'orangered'}">account_circle</mat-icon>
-          <span>Create New Account</span>
+        <button *ngIf="auth.user$ | async as user; else loggedOutUser" mat-menu-item (click)="logout()">
+          <mat-icon [ngStyle]="{'color':'orangered'}">logout</mat-icon>
+          <span>Logout</span>
         </button>
+        <ng-template #loggedOutUser>
+          <button mat-menu-item (click)="login(false)">
+            <mat-icon [ngStyle]="{'color':'orangered'}">login</mat-icon>
+            <span>Login</span>
+          </button>
+          <button mat-menu-item (click)="login(true)">
+            <mat-icon [ngStyle]="{'color':'orangered'}">account_circle</mat-icon>
+            <span>Create New Account</span>
+          </button>
+        </ng-template>
       </mat-menu>
+    </div>
+    <!-- TODO switch to their firstName when we connect backend -->
+    <span *ngIf="auth.user$ | async as user" class="">Hello 👋 {{ user.email }}</span>
   </mat-toolbar>
 
   <div class="homeSections">

--- a/Frontend/src/app/home/home.component.ts
+++ b/Frontend/src/app/home/home.component.ts
@@ -1,4 +1,6 @@
-import { Component } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { Component, Inject } from '@angular/core';
+import { AuthService } from '@auth0/auth0-angular';
 
 @Component({
   selector: 'app-home',
@@ -6,5 +8,25 @@ import { Component } from '@angular/core';
   styleUrls: ['./home.component.css','../../styles.css'],
 })
 export class HomeComponent {
+  constructor (public auth: AuthService, @Inject(DOCUMENT) public document: Document) {}
 
+  login(isSignUp: boolean) {
+    this.auth.loginWithRedirect({
+      appState: { 
+        target: this.document.location.pathname
+      },
+      authorizationParams: {
+        // Default selected login / signup
+        screen_hint: isSignUp ? 'signup' : 'signin'
+      }
+    });
+  }
+
+  logout() {
+    this.auth.logout({ 
+      logoutParams: {
+        returnTo: this.document.location.origin 
+      }
+    });
+  }
 }


### PR DESCRIPTION
Logged in state (mainly a proof of concept)
<img width="1512" alt="Screenshot 2024-09-24 at 9 03 06 PM" src="https://github.com/user-attachments/assets/aa4c7283-8111-4eec-9e2d-8b636099577b">

Logged out state
<img width="1512" alt="Screenshot 2024-09-24 at 9 03 19 PM" src="https://github.com/user-attachments/assets/a77dfafb-b0ce-404e-844c-59a70847e103">

I also added a small optimization so that if the user clicks "Create an Account" the auth0 popup automatically defaults them to the sign up option.

Some docs if anyone is interested
[https://auth0.com/docs/quickstart/spa/angular/interactive
](url)