### PR TITLE
Add create profile page functionality

### DIFF
--- a/Backend/handlers/handlers.go
+++ b/Backend/handlers/handlers.go
@@ -1,8 +1,11 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 
+	"fakebook.com/project/models"
 	"fakebook.com/project/profile"
 	"github.com/gin-gonic/gin"
 )
@@ -11,4 +14,27 @@ import (
 // GetUsersHandler returns all users
 func GetUsersHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, profile.Get())
+}
+
+func GetOneUserHandler(c *gin.Context) {
+	var1, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, http.StatusOK) // idk how to format this rn
+	}
+	c.JSON(http.StatusOK, profile.GetOneUser(var1))
+}
+
+func GetOneUserbyUsernameHandler(c *gin.Context) {
+	var username = c.Param("username")
+	c.JSON(http.StatusOK, profile.GetOneUserByUsername(username))
+}
+
+func AddNewUserHandler(c *gin.Context) {
+	var newUser models.User
+	err := c.ShouldBindJSON(&newUser)
+	if err != nil {
+		fmt.Println("we will deal with you later")
+	}
+	c.JSON(http.StatusOK, profile.AddNewUser(newUser))
+
 }

--- a/Backend/main.go
+++ b/Backend/main.go
@@ -25,9 +25,9 @@ var (
 )
 
 func main() {
-	setAuth0Variables()
+	// setAuth0Variables()
 	r := gin.Default()
-	r.Use(CORSMiddleware())
+	// r.Use(CORSMiddleware())
 
 	// This will ensure that the angular files are served correctly
 	r.NoRoute(func(c *gin.Context) {
@@ -47,9 +47,9 @@ func main() {
 	authorized := r.Group("/")
 	// authorized.Use(authRequired())
 	authorized.GET("/api/users", handlers.GetUsersHandler)
-	// authorized.POST("/todo", demoHandlers.AddTodoHandler)
-	// authorized.DELETE("/todo/:id", demoHandlers.DeleteTodoHandler)
-	// authorized.PUT("/todo", demoHandlers.CompleteTodoHandler)
+	authorized.GET("/api/user/:id", handlers.GetOneUserHandler)
+	authorized.GET("/api/username/:username", handlers.GetOneUserbyUsernameHandler)
+	authorized.PUT("/api/user/addNewUser", handlers.AddNewUserHandler)
 
 	err := r.Run(":3000")
 	if err != nil {

--- a/Backend/models/user-model.go
+++ b/Backend/models/user-model.go
@@ -1,9 +1,9 @@
 package models
 
 type User struct {
-	Name     string `json:"name"`
-	Age      int    `json:"age"`
-	HomeTown string `json:"homeTown"`
-	Job      string `json:"job"`
-	Username string `json:"username"`
+	Id        int    `json:"id"`
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+	Username  string `json:"username"`
+	Bio       string `json:"bio"`
 }

--- a/Backend/profile/profile.go
+++ b/Backend/profile/profile.go
@@ -1,6 +1,7 @@
 package profile
 
 import (
+	"fmt"
 	"sync"
 
 	"fakebook.com/project/models"
@@ -21,38 +22,62 @@ func initializeList() {
 	// in the future, we probably would not even need this
 	list = []models.User{
 		{
-			Name:     "Melissa",
-			Age:      29,
-			HomeTown: "Rochester, MN",
-			Job:      "Intern",
-			Username: "brownm26csp",
+			Id:        0,
+			FirstName: "Melissa",
+			LastName:  "Brown",
+			Username:  "melissa.cat.brown02@gmail.com",
 		},
 		{
-			Name:     "Avery",
-			Age:      22,
-			HomeTown: "Place, State",
-			Job:      "Professional",
-			Username: "averytribbett",
+			Id:        1,
+			FirstName: "Avery",
+			LastName:  "Tribbett",
+			Username:  "averytribbett",
 		},
 		{
-			Name:     "Cade",
-			Age:      23,
-			HomeTown: "different place, different state",
-			Job:      "Super professional",
-			Username: "cadegithub",
+			Id:        2,
+			FirstName: "Cade",
+			LastName:  "Becker",
+			Username:  "cadegithub",
 		},
 		{
-			Name:     "Youssef",
-			Age:      28,
-			HomeTown: "Yet another place, yet another state",
-			Job:      "Super ultra professional extraordinaire",
-			Username: "youssefgithub",
+			Id:        3,
+			FirstName: "Youssef",
+			LastName:  "Ibrahim",
+			Username:  "youssefgithub",
 		},
 	}
 }
 
 func Get() []models.User {
 	return list
+}
+
+func GetOneUser(userId int) models.User { // will return one user
+	var returnUser models.User
+	// replace lines 58-62 with call to database, this function might be obsolete eventually
+	for _, user := range list {
+		if user.Id == userId {
+			returnUser = user
+		}
+	}
+	return returnUser
+}
+
+func GetOneUserByUsername(username string) models.User {
+	var returnUser models.User
+	// replace lines 69-73 with calls to database
+	for _, user := range list {
+		if user.Username == username {
+			returnUser = user
+		}
+	}
+	return returnUser
+}
+
+func AddNewUser(newUser models.User) bool {
+	fmt.Println(newUser)
+	// add code to send newUser to database here
+	return true
 }
 
 /*

--- a/Frontend/src/app/app-routing.module.ts
+++ b/Frontend/src/app/app-routing.module.ts
@@ -3,12 +3,14 @@ import { RouterModule, Routes } from '@angular/router';
 import { HomeComponent } from './home/home.component';
 import { UserProfileComponent } from './user-profile/user-profile.component';
 import { UserFeedComponent } from './user-feed/user-feed.component';
+import { CreateProfileComponent } from './create-profile/create-profile.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
   { path: 'home', component: HomeComponent },
   { path: 'profile', component: UserProfileComponent},
-  { path: 'feed', component: UserFeedComponent}
+  { path: 'feed', component: UserFeedComponent},
+  { path: 'create-profile', component: CreateProfileComponent}
 ];
 
 @NgModule({

--- a/Frontend/src/app/app.module.ts
+++ b/Frontend/src/app/app.module.ts
@@ -8,6 +8,9 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatButtonModule } from '@angular/material/button';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { HttpClientModule } from '@angular/common/http';
+import {MatSelectModule} from '@angular/material/select';
+import {MatInputModule} from '@angular/material/input';
+import {MatFormFieldModule} from '@angular/material/form-field';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -20,6 +23,7 @@ import { ToastrModule } from 'ngx-toastr';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { provideAuth0 } from '@auth0/auth0-angular';
 import { environment } from 'src/environment';
+import { CreateProfileComponent } from './create-profile/create-profile.component';
 
 @NgModule({
   declarations: [
@@ -27,7 +31,8 @@ import { environment } from 'src/environment';
     HomeComponent,
     LoginPageComponent,
     UserProfileComponent,
-    UserFeedComponent
+    UserFeedComponent,
+    CreateProfileComponent,
   ],
   imports: [
     BrowserModule,
@@ -43,7 +48,10 @@ import { environment } from 'src/environment';
     MatButtonModule,
     MatMenuModule,
     MatToolbarModule,
-    HttpClientModule
+    HttpClientModule,
+    MatSelectModule,
+    MatInputModule,
+    MatFormFieldModule,
   ],
   providers: [
     provideAuth0({

--- a/Frontend/src/app/create-profile/create-profile.component.css
+++ b/Frontend/src/app/create-profile/create-profile.component.css
@@ -1,0 +1,37 @@
+#createProfileHeader {
+    border-bottom: 3px solid orangered;
+    box-shadow: 1px 2.5px 5px gray;
+}
+
+#createUserFields {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 100px;
+    width: 215px;
+    border: 1px solid orangered;
+    box-shadow: 1px 2.5px 5px gray;
+  }
+
+  #submitButton {
+    margin-top: 50px;
+    margin-left: 50%;
+    width: 50px;
+    background-color: orangered;
+    color: white;
+  }
+
+  #submitButton:hover {
+    background-color: #fcfbfa;
+    color: orangered;
+    border: 1px solid orangered;
+  }
+
+  #mainPageConainer {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: space-between;
+  }

--- a/Frontend/src/app/create-profile/create-profile.component.html
+++ b/Frontend/src/app/create-profile/create-profile.component.html
@@ -28,7 +28,7 @@
             <input matInput formControlName="lastName">
         </mat-form-field>
         <mat-form-field color="warn">
-            <mat-label for="bio">Bioz</mat-label>
+            <mat-label for="bio">Bio</mat-label>
             <input matInput formControlName="bio">
         </mat-form-field>
         <mat-form-field color="warn">

--- a/Frontend/src/app/create-profile/create-profile.component.html
+++ b/Frontend/src/app/create-profile/create-profile.component.html
@@ -1,3 +1,5 @@
+<!--probably add some functionality where, if a user has been redirected to create a profile, if they navigate away 
+ without clicking submit, it should log them out-->
 <mat-toolbar id="createProfileHeader">
     <button mat-icon-button class="example-icon" [matMenuTriggerFor]="menu" aria-label="Example icon-button with menu icon">
       <mat-icon [ngStyle]="{'color':'orangered'}">menu</mat-icon>
@@ -33,7 +35,7 @@
         </mat-form-field>
         <mat-form-field color="warn">
             <mat-label for="username">E-mail (TEST ONLY)</mat-label>
-            <input matInput formControlName="username">
+            <input matInput formControlName="username" [(ngModel)]="currentUser">
         </mat-form-field>
     </div>
   </form>

--- a/Frontend/src/app/create-profile/create-profile.component.html
+++ b/Frontend/src/app/create-profile/create-profile.component.html
@@ -1,0 +1,41 @@
+<mat-toolbar id="createProfileHeader">
+    <button mat-icon-button class="example-icon" [matMenuTriggerFor]="menu" aria-label="Example icon-button with menu icon">
+      <mat-icon [ngStyle]="{'color':'orangered'}">menu</mat-icon>
+    </button>
+    <span>Create Profile</span>
+    <span class="example-spacer"></span>
+    <mat-menu #menu="matMenu">
+        <button mat-menu-item (click)="showHomePage()">
+          <mat-icon [ngStyle]="{'color':'orangered'}">home</mat-icon>
+          <span>Home</span>
+        </button>
+        <button mat-menu-item>
+          <mat-icon [ngStyle]="{'color':'orangered'}">info</mat-icon>
+          <span>About</span>
+        </button>
+      </mat-menu>
+  </mat-toolbar>
+
+  <div id="mainPageContainer">
+  <form [formGroup]="createProfileForm">
+    <div id="createUserFields">
+        <mat-form-field color="warn">
+            <mat-label for="firstName">First Name</mat-label>
+            <input matInput formControlName="firstName">
+        </mat-form-field>
+        <mat-form-field color="warn">
+            <mat-label for="lastName">Last Name</mat-label>
+            <input matInput formControlName="lastName">
+        </mat-form-field>
+        <mat-form-field color="warn">
+            <mat-label for="bio">Bioz</mat-label>
+            <input matInput formControlName="bio">
+        </mat-form-field>
+        <mat-form-field color="warn">
+            <mat-label for="username">E-mail (TEST ONLY)</mat-label>
+            <input matInput formControlName="username">
+        </mat-form-field>
+    </div>
+  </form>
+  <button id="submitButton" mat-raised-button (click)="sendNewUserToBackend()">Submit</button>
+  </div>

--- a/Frontend/src/app/create-profile/create-profile.component.spec.ts
+++ b/Frontend/src/app/create-profile/create-profile.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CreateProfileComponent } from './create-profile.component';
+
+describe('CreateProfileComponent', () => {
+  let component: CreateProfileComponent;
+  let fixture: ComponentFixture<CreateProfileComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [CreateProfileComponent]
+    });
+    fixture = TestBed.createComponent(CreateProfileComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Frontend/src/app/create-profile/create-profile.component.ts
+++ b/Frontend/src/app/create-profile/create-profile.component.ts
@@ -1,0 +1,54 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { UserModel } from 'src/models/user-model';
+import { UserServiceService } from 'src/services/user-service.service';
+import {MatButton} from '@angular/material/button';
+import {MatTooltip} from '@angular/material/tooltip';
+import { AuthService } from '@auth0/auth0-angular';
+
+@Component({
+  selector: 'app-create-profile',
+  templateUrl: './create-profile.component.html',
+  styleUrls: ['./create-profile.component.css']
+})
+export class CreateProfileComponent {
+  @Input() currentUser: String = "";
+  @Output() myEmitter$ = new EventEmitter<boolean>();
+  public createProfileForm: FormGroup = new FormGroup({});
+
+  constructor(private userService: UserServiceService, public auth: AuthService){}
+  
+  ngOnInit(): void {
+    this.initForm();
+  }
+
+  public initForm(): void {
+    this.createProfileForm = new FormGroup({
+      firstName: new FormControl(''),
+      lastName: new FormControl(''),
+      bio: new FormControl(''),
+      username: new FormControl(''),
+    });
+  }
+
+  sendNewUserToBackend(): void {
+    const userToSend = {
+      firstName: this.createProfileForm.get('firstName')?.value,
+      lastName: this.createProfileForm.get('lastName')?.value,
+      bio: this.createProfileForm.get('bio')?.value,
+      username: this.currentUser ?? this.createProfileForm.get('username')?.value,
+    } as UserModel;
+
+    console.log('auth user: ', this.auth.user$);
+
+    this.userService.addNewUser(userToSend).subscribe(result => {
+      console.log('the result: ', result);
+      this.showHomePage();
+    });
+  }
+
+  public showHomePage(): void {
+    this.myEmitter$.emit(true);
+  }
+
+}

--- a/Frontend/src/app/create-profile/create-profile.component.ts
+++ b/Frontend/src/app/create-profile/create-profile.component.ts
@@ -9,7 +9,7 @@ import { AuthService } from '@auth0/auth0-angular';
 @Component({
   selector: 'app-create-profile',
   templateUrl: './create-profile.component.html',
-  styleUrls: ['./create-profile.component.css']
+  styleUrls: ['./create-profile.component.css'],
 })
 export class CreateProfileComponent {
   @Input() currentUser: String = "";
@@ -20,6 +20,7 @@ export class CreateProfileComponent {
   
   ngOnInit(): void {
     this.initForm();
+    this.disableUserNameField();
   }
 
   public initForm(): void {
@@ -51,4 +52,11 @@ export class CreateProfileComponent {
     this.myEmitter$.emit(true);
   }
 
+  public disableUserNameField(): void {
+    console.log('current user: ', this.currentUser);
+    console.log(this.currentUser !== null && this.currentUser !== "");
+    if (this.currentUser !== null && this.currentUser !== "") {
+      this.createProfileForm.get('username')?.disable();
+    }
+  }
 }

--- a/Frontend/src/app/home/home.component.html
+++ b/Frontend/src/app/home/home.component.html
@@ -1,7 +1,4 @@
-
-<button routerLink="/feed">user feed</button>
-<button routerLink="/profile">user profile</button>
-
+<div *ngIf="!shouldShowCreateProfile">
   <mat-toolbar id="header">
     <div class="header-left">
       <button mat-icon-button class="example-icon" [matMenuTriggerFor]="menu" aria-label="Example icon-button with menu icon">
@@ -31,7 +28,7 @@
       </mat-menu>
     </div>
     <!-- TODO switch to their firstName when we connect backend -->
-    <span *ngIf="auth.user$ | async as user" class="">Hello 👋 {{ user.email }}</span>
+    <span *ngIf="auth.user$ | async as user"  class="">Hello 👋 {{ user.email }}</span>
   </mat-toolbar>
 
   <div class="homeSections">
@@ -47,8 +44,12 @@
   <!--these two buttons are just for visiblity now, we can redirect users to the appropriate pages in a different manner later on-->
 <button routerLink="/feed">user feed</button>
 <button routerLink="/profile">user profile</button>
+<button (click)="showCreateProfilePage()">Create new user (test only)</button>
+</div>
 
-  <footer id="footer">Not affiliated with any other corporation involving books of faces (TM) not sure if we need a footer but here is one we could modify</footer>
+<app-create-profile *ngIf="shouldShowCreateProfile" [currentUser]="currentLoggedInUser" (myEmitter$)="switchToHomeView()"></app-create-profile>
+
+<footer id="footer">Not affiliated with any other corporation involving books of faces (TM) not sure if we need a footer but here is one we could modify</footer>
 
 
 

--- a/Frontend/src/app/home/home.component.ts
+++ b/Frontend/src/app/home/home.component.ts
@@ -1,6 +1,7 @@
 import { DOCUMENT } from '@angular/common';
 import { Component, Inject } from '@angular/core';
 import { AuthService } from '@auth0/auth0-angular';
+import { UserServiceService } from 'src/services/user-service.service';
 
 @Component({
   selector: 'app-home',
@@ -8,7 +9,26 @@ import { AuthService } from '@auth0/auth0-angular';
   styleUrls: ['./home.component.css','../../styles.css'],
 })
 export class HomeComponent {
-  constructor (public auth: AuthService, @Inject(DOCUMENT) public document: Document) {}
+  public shouldShowCreateProfile = false;
+  public currentLoggedInUser: String = "";
+
+  constructor (public auth: AuthService, @Inject(DOCUMENT) public document: Document, public userService: UserServiceService) {}
+
+  // a double subscribe like this is probably not best practice, but  for now it works
+  ngOnInit(): void {
+    this.auth.user$.subscribe(result => {
+      if (result) {
+        console.log('the username: ', result.name);
+        this.currentLoggedInUser = result.name as String;
+        this.userService.getUserByUsername(this.currentLoggedInUser).subscribe(result => {
+          console.log('searching current logged in user result: ', result);
+          if (!result || !result.username) {
+            this.shouldShowCreateProfile = true;
+          }
+        });
+      }
+    });
+  }
 
   login(isSignUp: boolean) {
     this.auth.loginWithRedirect({
@@ -18,8 +38,9 @@ export class HomeComponent {
       authorizationParams: {
         // Default selected login / signup
         screen_hint: isSignUp ? 'signup' : 'signin'
-      }
+      }    
     });
+    //this.showCreateProfile = isSignUp;
   }
 
   logout() {
@@ -28,5 +49,13 @@ export class HomeComponent {
         returnTo: this.document.location.origin 
       }
     });
+  }
+
+  switchToHomeView(): void {
+    this.shouldShowCreateProfile = false;
+  }
+
+  showCreateProfilePage(): void {
+    this.shouldShowCreateProfile = true;
   }
 }

--- a/Frontend/src/app/user-feed/user-feed.component.ts
+++ b/Frontend/src/app/user-feed/user-feed.component.ts
@@ -9,10 +9,9 @@ import { UserServiceService } from 'src/services/user-service.service';
 })
 export class UserFeedComponent {
   public selectedUser = {
-    name: "Please choose a name...",
-    age: 0,
-    homeTown: "",
-    job: "",
+    id: 0,
+    firstName: "Please choose a name...",
+    lastName: "",
     username: ""
   } as UserModel;
 

--- a/Frontend/src/app/user-profile/user-profile.component.html
+++ b/Frontend/src/app/user-profile/user-profile.component.html
@@ -1,16 +1,22 @@
 <h1>Welcome to your FakeBook(TM) Profile</h1>
-<h2>Name</h2>
-<p> {{ selectedUser.name }} </p>
-<h2>Age</h2>
-<p> {{ selectedUser.age }} </p>
-<h2>Home Town</h2>
-<p> {{ selectedUser.homeTown }} </p>
-<h2>Job</h2>
-<p> {{ selectedUser.job }} </p>
+<h2>First name</h2>
+<p> {{ selectedUser.firstName }} </p>
+<h2>Last name</h2>
+<p> {{ selectedUser.lastName }} </p>
+<h2>Username</h2>
+<p> {{ selectedUser.username }} </p>
+<h2>Bio</h2>
+<p> {{ selectedUser.bio }} </p>
 
 <select [(ngModel)]="selectedUser" (change)="changeSelectedUser($event)">
-    <option *ngFor="let user of availableUsers" [value]="user.name">
-      {{ user.name }}
+    <option *ngFor="let user of availableUsers" [value]="user.username">
+      {{ user.username }}
     </option>
-  </select>
+</select>
+<div>
+  <!-- for testing puproses, but will likely default to searching by e-mail-->
+  <label>Search User by ID</label>
+  <input type="text" [(ngModel)]="currentSearchUser">
+</div>
+<button (click)="searchForUser()">Search for user</button>
 <button routerLink="/">Back to Home</button>

--- a/Frontend/src/app/user-profile/user-profile.component.ts
+++ b/Frontend/src/app/user-profile/user-profile.component.ts
@@ -12,13 +12,13 @@ import { UserServiceService } from 'src/services/user-service.service';
 export class UserProfileComponent {
   public loginForm: FormGroup = new FormGroup({});
   public selectedUser = {
-    name: "Please choose a name...",
-    age: 0,
-    homeTown: "",
-    job: "",
+    id: 0,
+    firstName: "Please choose a name...",
+    lastName: "",
     username: ""
   } as UserModel;
   public availableUsers: UserModel[] = [];
+  public currentSearchUser: number = 0;
 
   constructor (private toaster: ToastrService, private userService: UserServiceService) {}
 
@@ -29,8 +29,17 @@ export class UserProfileComponent {
   }
 
   public changeSelectedUser(user: any): void {
-    const newUser = this.availableUsers.find(x => x.name === user.target.value) as UserModel;
+    const newUser = this.availableUsers.find(x => x.username === user.target.value) as UserModel;
     this.selectedUser = newUser;
   }
+
+  // this is searching by ID, not by e-mail
+  public searchForUser(): void {
+    this.userService.getUser(this.currentSearchUser).subscribe(result => {
+      console.log('results: ', result);
+      this.selectedUser = result;
+    });
+  }
+
 
 }

--- a/Frontend/src/models/user-model.ts
+++ b/Frontend/src/models/user-model.ts
@@ -1,8 +1,8 @@
 export interface UserModel {
-    name: string,
-    age: number,
-    homeTown: string,
-    job: string,
+    id?: number,
+    firstName: string,
+    lastName: string,
+    bio: string,
     username: string
 }
 

--- a/Frontend/src/services/user-service.service.ts
+++ b/Frontend/src/services/user-service.service.ts
@@ -13,4 +13,16 @@ export class UserServiceService {
   getAllUsers(): Observable<UserModel[]>{
     return this.httpClient.get<UserModel[]>("api/users");
   }
+
+  getUser(userId: number): Observable<UserModel>{
+    return this.httpClient.get<UserModel>("api/user/" + userId);
+  }
+
+  getUserByUsername(username: String): Observable<UserModel>{
+    return this.httpClient.get<UserModel>("api/username/" + username);
+  }
+
+  addNewUser(user: UserModel): Observable<boolean>{
+    return this.httpClient.put<boolean>("api/user/addNewUser", user);
+  }
 }


### PR DESCRIPTION
Styled Create Profile page

Added functionality to automatically route user to "create profile" page if their username is not in the database (using a hardcoded list for now)

Added functionality to keep user on home page if their username is in the database

In this image, there is a "create profile button" which can be used to test a database connection, but which will not be used for the final product
![image](https://github.com/user-attachments/assets/c5989871-dd2d-4e47-a8dd-c854d96ff1cd)

In this image, there is a field where you can put a username. This is just for testing - but I have it set that if the user arrived to this page via clicking on "create an account," then the e-mail they entered using Auth0 will override anything they enter here. Again, this is just for testing - we won't have the "e-mail" field available for the final product
![image](https://github.com/user-attachments/assets/84724469-96c2-4a17-827b-4aef5e6f8e91)

Pre-filled and disabled if user is signing up for first time:
![image](https://github.com/user-attachments/assets/18f5c722-4062-4b40-8f7c-17a5628ef8ca)


