### PR TITLE
Create profile redirect bug fix

### DIFF
--- a/Frontend/src/app/home/home.component.ts
+++ b/Frontend/src/app/home/home.component.ts
@@ -10,6 +10,7 @@ import { UserServiceService } from 'src/services/user-service.service';
 })
 export class HomeComponent {
   public shouldShowCreateProfile = false;
+  public shouldShowHomePage = false;
   public currentLoggedInUser: String = "";
 
   constructor (public auth: AuthService, @Inject(DOCUMENT) public document: Document, public userService: UserServiceService) {}
@@ -17,15 +18,26 @@ export class HomeComponent {
   // a double subscribe like this is probably not best practice, but  for now it works
   ngOnInit(): void {
     this.auth.user$.subscribe(result => {
+      // check if someone is signing up / logging in via auth0
       if (result) {
-        console.log('the username: ', result.name);
         this.currentLoggedInUser = result.name as String;
+
+        // check for user in database
         this.userService.getUserByUsername(this.currentLoggedInUser).subscribe(result => {
-          console.log('searching current logged in user result: ', result);
+
+          // if user does not exist in DB redirect to profile creation page else show home page
           if (!result || !result.username) {
             this.shouldShowCreateProfile = true;
           }
+          else {
+            this.shouldShowHomePage = true;
+          }
         });
+      }
+
+      // if no one logged in via auth0 default to home page view
+      else {
+        this.shouldShowHomePage = true;
       }
     });
   }
@@ -40,7 +52,6 @@ export class HomeComponent {
         screen_hint: isSignUp ? 'signup' : 'signin'
       }    
     });
-    //this.showCreateProfile = isSignUp;
   }
 
   logout() {
@@ -52,6 +63,7 @@ export class HomeComponent {
   }
 
   switchToHomeView(): void {
+    this.shouldShowHomePage = true;
     this.shouldShowCreateProfile = false;
   }
 


### PR DESCRIPTION
When the home page loads, if someone is logged in via auth0, it will not render either the home page nor the create profile page until it can determine if the user already has a profile or not.

If no one is logged in then the home page will render.