### PR TITLE
Add dialog warning if user has not completed profile yet

### DIFF
--- a/Frontend/src/app/app.module.ts
+++ b/Frontend/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { HttpClientModule } from '@angular/common/http';
 import {MatSelectModule} from '@angular/material/select';
 import {MatInputModule} from '@angular/material/input';
 import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatDialogModule} from '@angular/material/dialog';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -24,6 +25,7 @@ import { provideAuth0 } from '@auth0/auth0-angular';
 import { environment } from 'src/environment';
 import { CreateProfileComponent } from './create-profile/create-profile.component';
 import { DeveloperPageComponent } from './developer-page/developer-page.component';
+import { ProfileIncompleteWarningComponent } from './create-profile/profile-incomplete-warning/profile-incomplete-warning.component';
 
 @NgModule({
   declarations: [
@@ -33,6 +35,7 @@ import { DeveloperPageComponent } from './developer-page/developer-page.componen
     UserFeedComponent,
     CreateProfileComponent,
     DeveloperPageComponent,
+    ProfileIncompleteWarningComponent
   ],
   imports: [
     BrowserModule,
@@ -52,6 +55,7 @@ import { DeveloperPageComponent } from './developer-page/developer-page.componen
     MatSelectModule,
     MatInputModule,
     MatFormFieldModule,
+    MatDialogModule
   ],
   providers: [
     provideAuth0({

--- a/Frontend/src/app/create-profile/create-profile.component.html
+++ b/Frontend/src/app/create-profile/create-profile.component.html
@@ -7,7 +7,7 @@
     <span>Create Profile</span>
     <span class="example-spacer"></span>
     <mat-menu #menu="matMenu">
-        <button mat-menu-item (click)="showHomePage()">
+        <button mat-menu-item (click)="openProfileIncompleteDialog()">
           <mat-icon [ngStyle]="{'color':'orangered'}">home</mat-icon>
           <span>Home</span>
         </button>

--- a/Frontend/src/app/create-profile/create-profile.component.ts
+++ b/Frontend/src/app/create-profile/create-profile.component.ts
@@ -2,9 +2,11 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { UserModel } from 'src/models/user-model';
 import { UserServiceService } from 'src/services/user-service.service';
+import { MatDialog} from '@angular/material/dialog';
 import {MatButton} from '@angular/material/button';
 import {MatTooltip} from '@angular/material/tooltip';
 import { AuthService } from '@auth0/auth0-angular';
+import { ProfileIncompleteWarningComponent } from './profile-incomplete-warning/profile-incomplete-warning.component';
 
 @Component({
   selector: 'app-create-profile',
@@ -16,7 +18,11 @@ export class CreateProfileComponent {
   @Output() myEmitter$ = new EventEmitter<boolean>();
   public createProfileForm: FormGroup = new FormGroup({});
 
-  constructor(private userService: UserServiceService, public auth: AuthService){}
+  constructor(
+    private userService: UserServiceService,
+    public auth: AuthService,
+    public dialogRef: MatDialog
+  ){}
   
   ngOnInit(): void {
     this.initForm();
@@ -44,11 +50,23 @@ export class CreateProfileComponent {
 
     this.userService.addNewUser(userToSend).subscribe(result => {
       console.log('the result: ', result);
-      this.showHomePage();
     });
   }
 
-  public showHomePage(): void {
+  public openProfileIncompleteDialog(): void {
+    const myDialog = this.dialogRef.open(ProfileIncompleteWarningComponent, {
+      width: '250px',
+      disableClose: true,
+    });
+    myDialog.afterClosed().subscribe((result) => {
+      this.dialogRef.closeAll();
+      if (result) {
+        this.confirmReturnHome();
+      }
+    });
+  }
+
+  public confirmReturnHome(): void {
     this.myEmitter$.emit(true);
   }
 

--- a/Frontend/src/app/create-profile/profile-incomplete-warning/profile-incomplete-warning.component.html
+++ b/Frontend/src/app/create-profile/profile-incomplete-warning/profile-incomplete-warning.component.html
@@ -1,0 +1,7 @@
+<h2 mat-dialog-title>Profile creation incomplete</h2>
+<mat-dialog-content>
+  <p>If you leave this page, your profile will not be created. Do you wish to leave the page?</p>
+<mat-dialog-actions>
+  <button mat-button (click)="onNoClick()">No</button>
+  <button mat-button (click)="cancelProfileCreation()">Yes</button>
+</mat-dialog-actions>

--- a/Frontend/src/app/create-profile/profile-incomplete-warning/profile-incomplete-warning.component.spec.ts
+++ b/Frontend/src/app/create-profile/profile-incomplete-warning/profile-incomplete-warning.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProfileIncompleteWarningComponent } from './profile-incomplete-warning.component';
+
+describe('ProfileIncompleteWarningComponent', () => {
+  let component: ProfileIncompleteWarningComponent;
+  let fixture: ComponentFixture<ProfileIncompleteWarningComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ProfileIncompleteWarningComponent]
+    });
+    fixture = TestBed.createComponent(ProfileIncompleteWarningComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Frontend/src/app/create-profile/profile-incomplete-warning/profile-incomplete-warning.component.ts
+++ b/Frontend/src/app/create-profile/profile-incomplete-warning/profile-incomplete-warning.component.ts
@@ -1,0 +1,24 @@
+import { Component, EventEmitter, Inject, inject, Output } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-profile-incomplete-warning',
+  templateUrl: './profile-incomplete-warning.component.html',
+  styleUrls: ['./profile-incomplete-warning.component.css'],
+})
+export class ProfileIncompleteWarningComponent {
+  @Output() returnHomeEmitter$ = new EventEmitter<boolean>();
+  readonly dialogRef = inject(MatDialogRef<ProfileIncompleteWarningComponent>);
+
+  constructor(@Inject(MAT_DIALOG_DATA) public data: any){}
+
+  onNoClick(): void {
+    this.dialogRef.close(false);
+  }
+
+  cancelProfileCreation(): void {
+    this.dialogRef.close(true);
+  }
+
+}
+

--- a/Frontend/src/app/home/home.component.html
+++ b/Frontend/src/app/home/home.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="!shouldShowCreateProfile">
+<div *ngIf="shouldShowHomePage">
   <mat-toolbar id="header">
     <div class="header-left">
       <button mat-icon-button class="example-icon" [matMenuTriggerFor]="menu" aria-label="Example icon-button with menu icon">

--- a/Frontend/src/app/home/home.component.ts
+++ b/Frontend/src/app/home/home.component.ts
@@ -67,6 +67,7 @@ export class HomeComponent {
   switchToHomeView(): void {
     this.shouldShowHomePage = true;
     this.shouldShowCreateProfile = false;
+    this.logout();
   }
 
   showCreateProfilePage(): void {


### PR DESCRIPTION
If user attempts to leave profile creation page, a warning is given. If they choose to navigate away, they are logged out. If they choose to stay, they remain on the page

![image](https://github.com/user-attachments/assets/ee88497c-5782-476d-b864-2c6c36e21910)
