### PR TITLE
Modified initial feed by time

### DIFF
--- a/Backend/feed/feed.go
+++ b/Backend/feed/feed.go
@@ -145,10 +145,31 @@ func InitialFeedByTime(numOfPosts int, loggedInUserId int) []models.Post {
 	}
 
 	// sql query
-	query := "SELECT posts.post_id, posts.post_text, users.id AS user_id, users.first_name, users.last_name, (SELECT COUNT(*) FROM replies WHERE replies.post_id = posts.post_id) AS reply_count, (SELECT COUNT(*) FROM reactions WHERE reactions.post_id = posts.post_id) AS reaction_count, (SELECT reaction FROM reactions WHERE reactions.post_id = posts.post_id AND reactions.user_id = ?) AS reaction_by_user FROM posts JOIN users ON posts.user_id = users.id LEFT JOIN reactions ON posts.post_id = reactions.post_id ORDER BY posts.post_id DESC LIMIT " + strconv.Itoa(numOfPosts) + ";"
+	query := `WITH friend_usernames
+			  AS (SELECT CASE WHEN user_id = (SELECT username FROM capstone.users WHERE id = ?)
+			  	  THEN friend_id WHEN friend_id = (SELECT username FROM capstone.users WHERE id = ?)
+				  THEN user_id END AS friend_username FROM capstone.friends
+				  WHERE (user_id = (SELECT username FROM capstone.users WHERE id = ?)
+				  	OR friend_id = (SELECT username FROM capstone.users WHERE id = ?))
+				  AND friend_status = 'friends')
+			  SELECT posts.post_id, posts.post_text, users.id
+			  AS user_id, users.first_name, users.last_name,
+			  (SELECT COUNT(*) FROM replies
+			  	WHERE replies.post_id = posts.post_id)
+			  AS reply_count,
+			  (SELECT COUNT(*) FROM reactions WHERE reactions.post_id = posts.post_id)
+			  AS reaction_count,
+			  (SELECT reaction FROM reactions WHERE reactions.post_id = posts.post_id AND reactions.user_id = ?)
+			  AS reaction_by_user
+			  FROM posts
+			  JOIN users
+			  ON posts.user_id = users.id
+			  WHERE users.username
+			  IN (SELECT friend_username FROM friend_usernames)
+			  ORDER BY posts.post_id DESC LIMIT ?;`
 
 	// x rows of sql result
-	rows, err := db.Query(query, loggedInUserId)
+	rows, err := db.Query(query, loggedInUserId, loggedInUserId, loggedInUserId, loggedInUserId, loggedInUserId, numOfPosts)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Initial feed now only includes posts where a user is friends with someone

Credit to Youssef and Cade for helping with the query which I tested. Only merging it from me since I tested it and confirmed it to work.