### PR TITLE
Added admin frontend functionality

### DIFF
--- a/Backend/handlers/handlers.go
+++ b/Backend/handlers/handlers.go
@@ -16,12 +16,11 @@ import (
 	"fakebook.com/project/friends"
 	"fakebook.com/project/models"
 	"fakebook.com/project/profile"
-	// "fakebook.com/project/adminProfile"
+
 	"fakebook.com/project/reactions"
 	"github.com/gin-gonic/gin"
 )
 
-// main calls handlers, handlers calls... the other things?
 // GetUsersHandler returns all users
 func GetUsersHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, profile.Get())
@@ -154,7 +153,6 @@ func EditNameHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, profile.EditName(username, newNameSections[0], newNameSections[1]))
 }
 
-
 func EditFirstNameHandler(c *gin.Context) {
 	username := c.Param("username")
 	newFirstName := c.Param("newFirstName")
@@ -192,57 +190,57 @@ func DeleteUserHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, profile.DeleteUser(username))
 }
 
-func CheckAdminHandler(c *gin.Context){
+func CheckAdminHandler(c *gin.Context) {
 
-	adminId,err := strconv.Atoi(c.Param("adminId"))
+	adminId, err := strconv.Atoi(c.Param("adminId"))
 	if err != nil {
 		fmt.Println(err)
 	}
-	
+
 	c.JSON(http.StatusOK, profile.CheckAdmin(adminId))
 }
-func MakeUserAdminHandler(c *gin.Context){
+func MakeUserAdminHandler(c *gin.Context) {
 
-	adminId,err := strconv.Atoi(c.Param("adminId"))
-	userId,err := strconv.Atoi(c.Param("userId"))
+	adminId, err := strconv.Atoi(c.Param("adminId"))
+	userId, err := strconv.Atoi(c.Param("userId"))
 
 	if err != nil {
 		fmt.Println(err)
 	}
-	
-	c.JSON(http.StatusOK, profile.MakeUserAdmin(userId,adminId))
+
+	c.JSON(http.StatusOK, profile.MakeUserAdmin(userId, adminId))
 }
-func UnmakeUserAdminHandler(c *gin.Context){
+func UnmakeUserAdminHandler(c *gin.Context) {
 
-	adminId,err := strconv.Atoi(c.Param("adminId"))
-	userId,err := strconv.Atoi(c.Param("userId"))
+	adminId, err := strconv.Atoi(c.Param("adminId"))
+	userId, err := strconv.Atoi(c.Param("userId"))
 
 	if err != nil {
 		fmt.Println(err)
 	}
-	
+
 	c.JSON(http.StatusOK, profile.UnmakeUserAdmin(userId, adminId))
 }
-func DeletePostAdminHandler(c *gin.Context){
+func DeletePostAdminHandler(c *gin.Context) {
 
-	postId,err := strconv.Atoi(c.Param("postId"))
-	adminId,err := strconv.Atoi(c.Param("adminId"))
+	postId, err := strconv.Atoi(c.Param("postId"))
+	adminId, err := strconv.Atoi(c.Param("adminId"))
 
 	if err != nil {
 		fmt.Println(err)
 	}
-	
+
 	c.JSON(http.StatusOK, profile.DeletePostAdmin(postId, adminId))
 }
-func DeleteUserProfileAdminHandler(c *gin.Context){
+func DeleteUserProfileAdminHandler(c *gin.Context) {
 
-	adminId,err := strconv.Atoi(c.Param("adminId"))
+	adminId, err := strconv.Atoi(c.Param("adminId"))
 	username := c.Param("username")
 
 	if err != nil {
 		fmt.Println(err)
 	}
-	
+
 	c.JSON(http.StatusOK, profile.DeleteUserProfileAdmin(username, adminId))
 }
 
@@ -433,4 +431,3 @@ func GetProfilePictureHandler(db *sql.DB) gin.HandlerFunc {
 		})
 	}
 }
-

--- a/Backend/main.go
+++ b/Backend/main.go
@@ -60,8 +60,6 @@ func main() {
 
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:3306)/capstone", dbName, dbPass, dbHost)
 
-
-
 	// Open a connection to the database
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
@@ -109,8 +107,8 @@ func main() {
 	authorized.GET("/api/checkAdmin/:adminId", handlers.CheckAdminHandler)
 	authorized.PUT("/api/makeAdmin/:userId/:adminId", handlers.MakeUserAdminHandler)
 	authorized.DELETE("/api/unmakeAdmin/:userId/:adminId", handlers.UnmakeUserAdminHandler)
-	authorized.DELETE("/api/deletePostAdmin/:postId/:adminId", handlers.UnmakeUserAdminHandler)
-	authorized.DELETE("/api/deleteUserAdmin/:username/:adminId", handlers.UnmakeUserAdminHandler)
+	authorized.DELETE("/api/deletePostAdmin/:postId/:adminId", handlers.DeletePostAdminHandler)
+	authorized.DELETE("/api/deleteUserAdmin/:username/:adminId", handlers.DeleteUserProfileAdminHandler)
 
 	authorized.GET("/api/posts/user/:userID/:loggedInUserId", handlers.GetUserPostsHandler)
 	authorized.GET("/api/posts/initial/:numOfPosts/:loggedInUserId", handlers.GetInitialFeedByTimeHandler)

--- a/Frontend/src/app/components/user-post/user-post.component.html
+++ b/Frontend/src/app/components/user-post/user-post.component.html
@@ -125,6 +125,10 @@
         </ng-container>
       </button>
     </div>
+    <button *ngIf="loggedInUserIsAdmin" (click)="deletePost()" class="interaction-row">
+      <mat-icon class="icon">delete</mat-icon>
+      <p>Delete Post</p>
+    </button>
     <button (click)="openCommentInput()" class="interaction-row">
       <mat-icon class="icon">chat_bubble_outline</mat-icon>
       <p>Comment</p>

--- a/Frontend/src/app/components/user-post/user-post.component.ts
+++ b/Frontend/src/app/components/user-post/user-post.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ToastrService } from 'ngx-toastr';
 import { ReplyModel } from 'src/models/post-model';
 import { PostService } from 'src/services/posts-service.service';
@@ -22,6 +22,8 @@ export class UserPostComponent {
   @Input() postId!: number;
   @Input() userId!: number;
   @Input() loggedInUserId!: number;
+  @Input() loggedInUserIsAdmin: boolean = false;
+  @Output() shouldRefreshPosts: EventEmitter<boolean> = new EventEmitter<boolean>();
   public shouldShowCommentText = false;
   public commentText = '';
   public shouldShowComments = false;
@@ -121,9 +123,7 @@ export class UserPostComponent {
   openComments(): void {
     this.shouldShowComments = true;
     /** @TODO fetch comments from the post here */
-    console.log('Toggle open the comments');
     this.postService.getReplies(this.postId).subscribe((result) => {
-      console.log('the replies: ', result);
       this.replyList = result;
       this.comments = this.replyList.length;
     });
@@ -132,7 +132,6 @@ export class UserPostComponent {
   openCommentInput(): void {
     this.shouldShowCommentText = true;
     /** @TODO Should open input to leave comment on post */
-    console.log('Write a comment here');
   }
 
   comment(): void {
@@ -168,5 +167,12 @@ export class UserPostComponent {
     setTimeout(() => {
       this.showReactionTypes = value;
     }, 100);
+  }
+
+  deletePost(): void {
+    this.postService.deletePost(this.postId, this.loggedInUserId).subscribe(result => {
+      this.toasterService.show('Post deleted successfully!');
+      this.shouldRefreshPosts.emit(true);
+    });
   }
 }

--- a/Frontend/src/app/create-profile/create-profile.component.html
+++ b/Frontend/src/app/create-profile/create-profile.component.html
@@ -39,7 +39,7 @@
         <input matInput formControlName="bio" />
       </mat-form-field>
       <mat-form-field color="warn">
-        <mat-label for="username">E-mail (TEST ONLY)</mat-label>
+        <mat-label for="username">E-mail </mat-label>
         <input matInput formControlName="username" [(ngModel)]="currentUser" />
       </mat-form-field>
     </div>

--- a/Frontend/src/app/create-profile/create-profile.component.ts
+++ b/Frontend/src/app/create-profile/create-profile.component.ts
@@ -83,7 +83,7 @@ export class CreateProfileComponent {
   }
 
   public disableUserNameField(): void {
-    if (this.currentUser !== null && this.currentUser !== '') {
+    if (this.currentUser !== null && this.currentUser !== '' && !this.isDeveloperMode) {
       this.createProfileForm.get('username')?.disable();
     }
   }

--- a/Frontend/src/app/developer-page/developer-page.component.ts
+++ b/Frontend/src/app/developer-page/developer-page.component.ts
@@ -19,9 +19,7 @@ export class DeveloperPageComponent {
       this.isDeveloper = params['isDevelopmentEnvironment'];
       this.userService.getAllUsers().subscribe(result => {
         this.userList = result;
-        console.log("USER LIST IN SUB", this.userList);  
       });
-      console.log("USER LIST AFTER SUB", this.userList);
     });
   }
 }

--- a/Frontend/src/app/home/home.component.html
+++ b/Frontend/src/app/home/home.component.html
@@ -117,14 +117,12 @@
           [userId]="post.authorId"
           [loggedInUserId]="currentUser.id || -1"
           [initialReactionByUser]="post.reactionByUser"
+          [loggedInUserIsAdmin]="userService.getBoolean()"
+          (shouldRefreshPosts)="getInitialPosts()"
         ></user-post>
       </div>
     </div>
     <ng-template #showLogo>
-      <!-- <div id="homeDescription" class="homeOptions">
-          Short description of our app and how your life will be immeasurably better once you start to use it.
-          Facebook, shmacebook. 
-      </div> -->
       <div class="homeOptions">
         <img src="../images/paper_plane.jpg" alt="Logo" />
       </div>
@@ -133,5 +131,4 @@
   <mat-spinner *ngIf="isLoading" class="spinner"></mat-spinner>
 </div>
 
-<!--getting rid of footer for now because it was in the way and we can add it back later if necessary-->
-<!-- <footer id="footer">Not affiliated with any other corporation involving books of faces (TM) not sure if we need a footer but here is one we could modify</footer> -->
+

--- a/Frontend/src/app/home/home.component.ts
+++ b/Frontend/src/app/home/home.component.ts
@@ -51,7 +51,7 @@ export class HomeComponent {
     this.document.addEventListener('scroll', this.onScroll.bind(this));
   }
 
-  // a double subscribe like this is probably not best practice, but  for now it works
+  
   ngOnInit(): void {
     this.userService.userAuth.user$.subscribe((result) => {
       // check if someone is signing up / logging in via auth0
@@ -70,14 +70,10 @@ export class HomeComponent {
             } else {
               this.router.navigate(['/home']);
               this.currentUser = result;
-              this.postService
-                .getInitialFeedByTime(20, this.currentUser.id || -1)
-                .subscribe((result) => {
-                  if (result.length) {
-                    console.log(result);
-                    this.feed = result;
-                  }
-                });
+              this.userService.userIsAdmin(this.currentUser.id as number).subscribe(result => {
+                this.userService.setBoolean(result);
+              });
+              this.getInitialPosts();
             }
           });
       }
@@ -104,6 +100,16 @@ export class HomeComponent {
       }
     });
     this.initPostForm();
+  }
+
+  public getInitialPosts() {
+    this.postService
+    .getInitialFeedByTime(20, this.currentUser.id || -1)
+    .subscribe((result) => {
+      if (result.length) {
+        this.feed = result;
+      }
+    });
   }
 
   public initPostForm(): void {

--- a/Frontend/src/app/user-profile/user-profile.component.html
+++ b/Frontend/src/app/user-profile/user-profile.component.html
@@ -20,7 +20,7 @@
         </button>
         <button
           mat-menu-item
-          *ngIf="shouldHaveWriteAccess && !isEditing"
+          *ngIf="(shouldHaveWriteAccess || loggedInUserIsAdmin) && !isEditing"
           (click)="editProfile()"
         >
           <mat-icon [ngStyle]="{ color: 'orangered' }">edit</mat-icon>
@@ -28,7 +28,7 @@
         </button>
         <button
           mat-menu-item
-          *ngIf="shouldHaveWriteAccess && isEditing"
+          *ngIf="(shouldHaveWriteAccess || loggedInUserIsAdmin) && isEditing"
           (click)="cancelEditing()"
         >
           <mat-icon [ngStyle]="{ color: 'orangered' }">block</mat-icon>
@@ -90,6 +90,30 @@
       >
         Friend Requests
       </button>
+      <button
+      *ngIf="loggedInUserIsAdmin && !profileBeingViewedIsAdmin"
+      mat-stroked-button
+      class="manage-friend-button"
+      (click)="makeUserAdmin()"
+    >
+      Make Admin
+    </button>
+    <button
+    *ngIf="loggedInUserIsAdmin && profileBeingViewedIsAdmin"
+    mat-stroked-button
+    class="manage-friend-button"
+    (click)="revokeUserAdmin()"
+    >
+      Revoke Admin Privileges
+    </button>
+    <button
+    *ngIf="loggedInUserIsAdmin"
+    mat-stroked-button
+    class="manage-friend-button"
+    (click)="deleteUser()"
+    >
+      Delete User
+    </button>
     </div>
     <div *ngIf="isEditing" id="profile-edit-info">
       <mat-label>Please select an item to edit:</mat-label>
@@ -145,7 +169,7 @@
 </button>
 
 <div
-  *ngIf="shouldShowProfileFeed && (shouldHaveWriteAccess || shouldShowDeleteFriendButton)"
+  *ngIf="shouldShowProfileFeed && (shouldHaveWriteAccess || shouldShowDeleteFriendButton || loggedInUserIsAdmin)"
   id="posts"
 >
   <div *ngFor="let post of userPosts">
@@ -160,6 +184,8 @@
       [userId]="post.authorId"
       [loggedInUserId]="loggedInUserId"
       [initialReactionByUser]="post.reactionByUser"
+      [loggedInUserIsAdmin]="loggedInUserIsAdmin"
+      (shouldRefreshPosts)="getUserPosts()"
     ></user-post>
   </div>
 </div>
@@ -176,7 +202,7 @@
   </mat-card-subtitle>
 </mat-card>
 <mat-card
-  *ngIf="shouldShowFriendList && (shouldHaveWriteAccess || shouldShowDeleteFriendButton)"
+  *ngIf="shouldShowFriendList && (shouldHaveWriteAccess || shouldShowDeleteFriendButton || loggedInUserIsAdmin)"
   appearance="raised"
 >
   <mat-card-title>Friend list</mat-card-title>

--- a/Frontend/src/models/user-model.ts
+++ b/Frontend/src/models/user-model.ts
@@ -23,6 +23,7 @@ export interface PostModel {
 }
 
 export const profileEditOptions = ['First Name', 'Last Name', 'Bio'];
+export const isAdmin = 'isAdmin';
 
 export enum EditOptions {
   FirstName = 'First Name',

--- a/Frontend/src/services/posts-service.service.ts
+++ b/Frontend/src/services/posts-service.service.ts
@@ -45,7 +45,6 @@ export class PostService {
   }
 
   addComment(reply: ReplyModel): Observable<boolean> {
-    console.log('reply: ', reply);
     return this.httpClient.post<boolean>(`api/posts/reply`, reply);
   }
 
@@ -81,5 +80,9 @@ export class PostService {
     return this.httpClient.delete<boolean>(
       `api/reactions/deleteReaction/${post_id}/${user_id}`,
     );
+  }
+
+  deletePost(postId: number, adminId: number): Observable<boolean> {
+    return this.httpClient.delete<boolean>(`/api/deletePostAdmin/${postId}/${adminId}`);
   }
 }

--- a/Frontend/src/services/user-service.service.ts
+++ b/Frontend/src/services/user-service.service.ts
@@ -2,13 +2,14 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { AuthService } from '@auth0/auth0-angular';
 import { Observable } from 'rxjs';
-import { UserModel } from 'src/models/user-model';
+import { isAdmin, UserModel } from 'src/models/user-model';
 
 @Injectable({
   providedIn: 'root',
 })
 export class UserServiceService {
   public loggedInUsername = '';
+  public loggedInUserIsAdmin = false;
 
   constructor(
     private httpClient: HttpClient,
@@ -57,7 +58,6 @@ export class UserServiceService {
     newFirstName: string,
     username: string,
   ): Observable<boolean> {
-    console.log('we are editing the first name');
     return this.httpClient.patch<boolean>(
       `/api/user/editFirstName/${newFirstName}/${username}`,
       null,
@@ -68,16 +68,28 @@ export class UserServiceService {
     newLastName: string,
     username: string,
   ): Observable<boolean> {
-    console.log('we are editing the last name');
     return this.httpClient.patch<boolean>(
       `/api/user/editLastName/${newLastName}/${username}`,
       null,
     );
   }
 
+  userIsAdmin(userId: number): Observable<boolean> {
+    return this.httpClient.get<boolean>(`/api/checkAdmin/${userId}`);
+  }
+
   setValue(value: string) {
     this.loggedInUsername = value;
     localStorage.setItem('myValue', value);
+  }
+
+  setBoolean(value: boolean): void {
+    localStorage.setItem(isAdmin, value.toString());
+  }
+
+  getBoolean(): boolean {
+    const storedValue = localStorage.getItem(isAdmin);
+    return storedValue === 'true';
   }
 
   getValue() {
@@ -101,5 +113,17 @@ export class UserServiceService {
 
   getProfilePictureUrl(imageName: string): string {
     return `/uploads/${imageName}`;
+  }
+
+  makeUserAdmin(pendingAdminUserId: number, adminUserId: number): Observable<boolean> {
+    return this.httpClient.put<boolean>(`/api/makeAdmin/${pendingAdminUserId}/${adminUserId}`, null);
+  }
+
+  revokeUserAdmin(pendingRevokeAdminUserId: number, adminUserId: number): Observable<boolean> {
+    return this.httpClient.delete<boolean>(`/api/unmakeAdmin/${pendingRevokeAdminUserId}/${adminUserId}`);
+  }
+
+  deleteUser(usernameToDelete: string, adminUserId: number): Observable<boolean> {
+    return this.httpClient.delete<boolean>(`/api/deleteUserAdmin/${usernameToDelete}/${adminUserId}`);
   }
 }


### PR DESCRIPTION
Ability to:

1. Make a user an admin
2. Revoke a user's admin status
3. delete a user
4. delete a post
5. see all details of a user's profile no matter their friend status
![image](https://github.com/user-attachments/assets/576b906c-18e5-4887-8da5-c7f611e5d40b)
In the above picture, I have the ability to make Cade an admin, see his posts even though we are not friends, edit his profile even though I'm not logged in as him, and delete his profile
![image](https://github.com/user-attachments/assets/08ccfa55-801c-44c2-a666-ae8e8f6ef582)
In this screenshot, Yoseph is an admin but I can revoke his admin privileges
![image](https://github.com/user-attachments/assets/5a5d793f-2bab-40fd-b89c-8eb4561bf5f9)
Finally, I can delete this filthy post claiming that "hot dogs are sandwiches" when they are indeed, not (and I did delete it)